### PR TITLE
Replace sleep-based CPU throttling with time-sliced yielding (test suite 50.5s → 1.6s)

### DIFF
--- a/src/bloom.ts
+++ b/src/bloom.ts
@@ -18,6 +18,8 @@ export class BloomFilter {
   private readonly hashFunctions: number;
   private readonly addedItems: Set<string> = new Set(); // Track added items for debugging
   private maxTrackedItems = 10000; // Limit tracked items to prevent memory leak
+  /** Memoized popCount(); -1 means "recompute". Reset by every write path. */
+  private cachedPopCount = -1;
 
   /**
    * Creates a new bloom filter
@@ -92,6 +94,26 @@ export class BloomFilter {
       const bitOffset = bitIndex % 32;
       this.bitArray[arrayIndex] |= 1 << bitOffset;
     }
+    this.cachedPopCount = -1;
+  }
+
+  /**
+   * Number of bits set, memoized.
+   *
+   * A filter's own population count is invariant between mutations, but
+   * similarity() needs it on both sides of every pairwise comparison. Computing
+   * it per pair made a query O(candidates) redundant popcount passes over the
+   * same query filter. Every write path below resets the memo.
+   */
+  popCount(): number {
+    if (this.cachedPopCount < 0) {
+      let bits = 0;
+      for (let i = 0; i < this.bitArray.length; i++) {
+        bits += countBits(this.bitArray[i]);
+      }
+      this.cachedPopCount = bits;
+    }
+    return this.cachedPopCount;
   }
 
   /**
@@ -126,6 +148,7 @@ export class BloomFilter {
   setBitArray(array: Uint32Array): void {
     if (array.length === this.bitArray.length) {
       this.bitArray = array;
+      this.cachedPopCount = -1;
     } else {
       throw new Error(`Array length mismatch: got ${array.length}, expected ${this.bitArray.length}`);
     }
@@ -204,6 +227,7 @@ export class BloomFilter {
       throw new Error(`Cannot deserialize: size/hash mismatch. Expected ${this.size}/${this.hashFunctions}, got ${data.size}/${data.hashFunctions}`);
     }
     this.bitArray = new Uint32Array(data.bitArray);
+    this.cachedPopCount = -1;
     this.addedItems.clear(); // Clear tracked items since we don't serialize them
   }
 
@@ -212,6 +236,7 @@ export class BloomFilter {
    */
   clear(): void {
     this.bitArray.fill(0);
+    this.cachedPopCount = -1;
     this.addedItems.clear();
   }
 
@@ -227,26 +252,18 @@ export class BloomFilter {
       return 0;
     }
 
+    // Each filter's own population count depends only on that filter, so it is
+    // cached and reused across every comparison in a query instead of being
+    // recomputed per pair. |A|+|B| are then enough to derive the union without
+    // a second popcount pass: |A ∪ B| = |A| + |B| - |A ∩ B|.
+    const thisBits = this.popCount();
+    const otherBits = other.popCount();
+
     let intersectionBits = 0;
-    let unionBits = 0;
-    let thisBits = 0;
-    let otherBits = 0;
-
     for (let i = 0; i < this.bitArray.length; i++) {
-      const intersection = this.bitArray[i] & other.bitArray[i];
-      const union = this.bitArray[i] | other.bitArray[i];
-
-      // Count bits in each array
-      const thisCount = countBits(this.bitArray[i]);
-      const otherCount = countBits(other.bitArray[i]);
-
-      // Count bits in intersection and union
-      intersectionBits += countBits(intersection);
-      unionBits += countBits(union);
-
-      thisBits += thisCount;
-      otherBits += otherCount;
+      intersectionBits += countBits(this.bitArray[i] & other.bitArray[i]);
     }
+    const unionBits = thisBits + otherBits - intersectionBits;
 
     // Check for nearly empty documents
     const minBitsRequired = 5; // Minimum number of bits set to consider meaningful
@@ -272,9 +289,13 @@ export class BloomFilter {
       similarity = similarity * Math.pow(1 - saturationFactor, 2);
     }
 
-    const rawSimilarity = unionBits === 0 ? 0 : intersectionBits / unionBits;
-    logIfDebugModeEnabled(
-      `Similarity details:
+    // Guarded: this runs once per candidate document, so building the message
+    // unconditionally would allocate a multi-line string and run six toFixed()
+    // calls on every comparison even with debug mode off.
+    if (isDebugMode()) {
+      const rawSimilarity = unionBits === 0 ? 0 : intersectionBits / unionBits;
+      logIfDebugModeEnabled(
+        `Similarity details:
       - Filter 1: ${thisBits} bits set (${(thisRatio * 100).toFixed(1)}% of capacity)
       - Filter 2: ${otherBits} bits set (${(otherRatio * 100).toFixed(1)}% of capacity)
       - Intersection: ${intersectionBits} bits
@@ -282,7 +303,8 @@ export class BloomFilter {
       - Items in filter 1: ${this.addedItems.size}
       - Items in filter 2: ${other.addedItems.size}
       - Raw similarity: ${(rawSimilarity * 100).toFixed(2)}%`
-    );
+      );
+    }
 
     return similarity;
   }

--- a/src/multi-bloom.ts
+++ b/src/multi-bloom.ts
@@ -10,6 +10,7 @@ import { BloomFilter } from './bloom';
 import { WordBasedCandidateSelector } from './word-index';
 import { normalizePath, TFile, Vault } from 'obsidian';
 import { isDebugMode, logIfDebugModeEnabled, logMetrics, logPerformance } from './logging';
+import { TimeSlicer } from './scheduler';
 import {
   TEXT_PROCESSING,
   BLOOM_FILTER,
@@ -482,19 +483,13 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
       const markdownFiles = this.vault.getMarkdownFiles();
       logIfDebugModeEnabled(`Starting fresh indexing: ${totalFiles} markdown files`);
 
-      // Improved yielding function
-      const yield_to_main = async () => {
-        await new Promise(resolve => setTimeout(resolve, 15)); // 15ms yield gives UI more breathing room
-      };
-
       // Process files in smaller batches for better UI responsiveness
       const batchSize = BATCH_PROCESSING.SMALL_BATCH_SIZE; // Even smaller batch size for more frequent UI updates
       let processedCount = 0;
 
-      // Enhanced yielding function with variable durations
-      const yieldWithDuration = async (ms: number) => {
-        await new Promise(resolve => setTimeout(resolve, ms));
-      };
+      // Yield when the frame budget is spent instead of sleeping a fixed
+      // duration per batch/per N files. See src/scheduler.ts.
+      const slicer = new TimeSlicer();
 
       // Single optimized pass - process all files with smart batching
       const filesToProcess = markdownFiles;
@@ -519,8 +514,8 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
           onProgress(processedCount, totalFiles);
         }
 
-        // Longer yield before processing batch
-        await yieldWithDuration(20);
+        // Give the UI a chance to paint the progress update, if we owe it one.
+        await slicer.tick();
 
         // Process each file in the batch
         for (const file of batch) {
@@ -550,10 +545,8 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
               (onProgress as any)(processedCount, totalFiles, file.path);
             }
 
-            // Yield every 5 files to keep UI responsive
-            if (processedCount % 5 === 0) {
-              await yieldWithDuration(10); // Quick yield
-            }
+            // Keep the UI responsive without idling between files.
+            await slicer.tick();
 
             // Save cache periodically during indexing to preserve progress
             if (processedCount % 50 === 0) {
@@ -566,9 +559,7 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
         }
 
         // Yield between batches to keep UI responsive
-        if (i % (batchSize * 2) === 0) {
-          await yieldWithDuration(20); // Quick yield between batches
-        }
+        await slicer.tick();
       }
 
       // Clear current file tracking
@@ -862,13 +853,8 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
     this.cacheDirty = true;
     const startTime = performance.now();
 
-    // More aggressive yielding to ensure UI responsiveness
-    const yieldWithDuration = async (ms: number) => {
-      await new Promise(resolve => setTimeout(resolve, ms));
-    };
-
-    // Initial yield before any processing
-    await yieldWithDuration(TIMING.YIELD_DURATION_MS);
+    // Yield whenever this document's work has held the main thread for a frame.
+    const slicer = new TimeSlicer();
 
     // Skip adaptive parameters for better performance
     this.documentsProcessed++;
@@ -886,12 +872,12 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
 
     // Track word frequencies for adaptive stopwords
     this.trackWordFrequencies(docId, limitedText);
-    await yieldWithDuration(TIMING.YIELD_DURATION_MS);
+    await slicer.tick();
 
     // Compute common words if enough documents processed
     if (this.totalDocuments >= 30 && !this.commonWordsComputed) {
       this.computeCommonWords();
-      await yieldWithDuration(TIMING.EXTENDED_YIELD_DURATION_MS);
+      await slicer.tick();
     }
 
     // Create a simplified bloom filter with adaptive size for large vaults
@@ -904,18 +890,22 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
 
     // Pre-process text to filter stopwords if we've computed them
     const processed = this.preprocessText(limitedText);
-    await yieldWithDuration(TIMING.YIELD_DURATION_MS);
+    await slicer.tick();
 
-    // CPU throttling: process in small chunks with mandatory yields
+    // Feed the filter in chunks so a very long document cannot hold the main
+    // thread, yielding only once a chunk has actually overrun the frame budget.
+    //
+    // CHUNK_SIZE must not change: extractWords() derives bigrams within each
+    // chunk and caps them per chunk, so the chunk boundaries are part of what
+    // ends up in the filter. Resizing chunks would silently change similarity
+    // scores for every document.
     const words = processed.split(/\s+/);
-    const CHUNK_SIZE = TIMING.MAX_OPERATIONS_BEFORE_YIELD; // Small chunks to prevent CPU hogging
+    const CHUNK_SIZE = TIMING.MAX_OPERATIONS_BEFORE_YIELD;
 
     for (let i = 0; i < words.length; i += CHUNK_SIZE) {
       const chunk = words.slice(i, i + CHUNK_SIZE).join(' ');
       filter.addText(chunk);
-
-      // Mandatory yield after every chunk to keep UI responsive
-      await yieldWithDuration(TIMING.MIN_YIELD_TIME_MS);
+      await slicer.tick();
     }
 
     // Store the filter
@@ -923,16 +913,13 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
 
     // Also add to word-based candidate selector for fast candidate selection
     if (this.useWordBasedCandidates) {
-      await yieldWithDuration(5);
+      await slicer.tick();
       this.wordCandidateSelector.addDocument(docId, limitedText);
     }
 
     // No longer storing n-grams for memory efficiency
 
     const endTime = performance.now();
-
-    // Final yield to ensure UI responsiveness
-    await yieldWithDuration(5);
 
     if (isDebugMode()) {
       logIfDebugModeEnabled(`Processed document ${docId} in ${(endTime - startTime).toFixed(2)}ms`);
@@ -1176,7 +1163,7 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
     const results: [string, number][] = [];
     let comparisons = 0;
     let skippedComparisons = 0;
-    let operationsSinceYield = 0;
+    const slicer = new TimeSlicer();
 
     // Determine which documents to compare against
     let documentsToProcess: Iterable<[string, any]>;
@@ -1212,11 +1199,9 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
     for (const [docId, filter] of documentsToProcess) {
       if (docId === queryDocId) continue; // Skip self-comparison
 
-      // CPU throttling: yield control after processing a batch
-      if (++operationsSinceYield >= TIMING.MAX_OPERATIONS_BEFORE_YIELD) {
-        await new Promise(resolve => setTimeout(resolve, TIMING.MIN_YIELD_TIME_MS));
-        operationsSinceYield = 0;
-      }
+      // Keep the main thread free: yield once the frame budget is spent rather
+      // than sleeping every N comparisons.
+      await slicer.tick();
 
       comparisons++;
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,99 @@
+/**
+ * @file Cooperative scheduling primitives.
+ *
+ * The plugin needs to stay responsive while doing long CPU-bound passes
+ * (indexing the vault, comparing bloom filters). The original approach was to
+ * sleep — `await new Promise(r => setTimeout(r, 16))` every N operations — but
+ * sleeping does not make the UI more responsive than simply yielding, it just
+ * idles the CPU. On a 5,000-file vault that cost tens of seconds of pure idle
+ * time, dwarfing the actual work.
+ *
+ * What responsiveness actually requires is never occupying the main thread for
+ * longer than a frame. That is what `TimeSlicer` does: run work until the
+ * budget is spent, hand control back to the event loop, then continue.
+ */
+
+/**
+ * Default main-thread budget between yields, in milliseconds. Half a 60fps
+ * frame, so a slice plus the surrounding frame work still lands inside 16.7ms.
+ */
+export const DEFAULT_SLICE_BUDGET_MS = 8;
+
+/** Pending resolvers, drained one per port message. */
+const pending: Array<() => void> = [];
+let channel: MessageChannel | null = null;
+
+function port(): MessagePort {
+  if (!channel) {
+    channel = new MessageChannel();
+    // Assigning onmessage implicitly starts the port.
+    channel.port1.onmessage = () => pending.shift()?.();
+  }
+  return channel.port2;
+}
+
+/**
+ * Hand control back to the event loop, allowing input handling and paint, then
+ * resume as soon as possible.
+ *
+ * Uses `scheduler.yield()` where available (Chromium 129+, which recent
+ * Obsidian builds ship), otherwise a MessageChannel round-trip. MessageChannel
+ * is used in preference to `setTimeout(0)` because nested timers are clamped to
+ * 4ms by browsers and Electron, whereas port messages are not — measured at
+ * ~0.02ms per yield versus ~1.2ms for `setTimeout(0)` and ~17ms for
+ * `setTimeout(16)`.
+ */
+export function yieldToMain(): Promise<void> {
+  const scheduler = (globalThis as { scheduler?: { yield?: () => Promise<void> } }).scheduler;
+  if (scheduler && typeof scheduler.yield === "function") {
+    return scheduler.yield();
+  }
+  return new Promise<void>((resolve) => {
+    pending.push(resolve);
+    port().postMessage(null);
+  });
+}
+
+/**
+ * Yields only once the main thread has been held for longer than the budget,
+ * so short passes never yield at all and long ones stay frame-friendly.
+ *
+ * Replaces fixed "yield every N operations" throttling, which cannot know how
+ * expensive an operation is: 10 comparisons take microseconds, 10 file reads
+ * take milliseconds. Budgeting by elapsed time adapts to both, and to the
+ * speed of the machine.
+ *
+ * ```ts
+ * const slicer = new TimeSlicer();
+ * for (const item of items) {
+ *   await slicer.tick();
+ *   process(item);
+ * }
+ * ```
+ */
+export class TimeSlicer {
+  private deadline: number;
+  private yields = 0;
+
+  constructor(private readonly budgetMs: number = DEFAULT_SLICE_BUDGET_MS) {
+    this.deadline = performance.now() + budgetMs;
+  }
+
+  /** Yield if the current slice is exhausted; otherwise return immediately. */
+  async tick(): Promise<void> {
+    if (performance.now() < this.deadline) return;
+    await yieldToMain();
+    this.yields++;
+    this.deadline = performance.now() + this.budgetMs;
+  }
+
+  /** Start a fresh slice, e.g. after an await that already gave up the thread. */
+  reset(): void {
+    this.deadline = performance.now() + this.budgetMs;
+  }
+
+  /** Number of yields performed; used by the performance regression tests. */
+  get yieldCount(): number {
+    return this.yields;
+  }
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -23,6 +23,9 @@ export const DEFAULT_SLICE_BUDGET_MS = 8;
 const pending: Array<() => void> = [];
 let channel: MessageChannel | null = null;
 
+/** True in a renderer (Obsidian, browser); false under bare Node (tests, CI). */
+const hasDom = typeof document !== "undefined";
+
 function port(): MessagePort {
   if (!channel) {
     channel = new MessageChannel();
@@ -36,17 +39,26 @@ function port(): MessagePort {
  * Hand control back to the event loop, allowing input handling and paint, then
  * resume as soon as possible.
  *
- * Uses `scheduler.yield()` where available (Chromium 129+, which recent
- * Obsidian builds ship), otherwise a MessageChannel round-trip. MessageChannel
- * is used in preference to `setTimeout(0)` because nested timers are clamped to
+ * Uses `scheduler.yield()` where available (Chromium 129+, which recent Obsidian
+ * builds ship), then a MessageChannel round-trip in any renderer. MessageChannel
+ * is preferred over `setTimeout(0)` there because nested timers are clamped to
  * 4ms by browsers and Electron, whereas port messages are not — measured at
  * ~0.02ms per yield versus ~1.2ms for `setTimeout(0)` and ~17ms for
  * `setTimeout(16)`.
+ *
+ * Under bare Node (tests, CI) `setImmediate` is used instead. An open
+ * MessagePort is an active libuv handle, so a Node process that yielded via the
+ * channel would never exit; ref/unref'ing it around each yield fixes that but
+ * costs more than the yield itself. `setImmediate` is the correct Node
+ * macrotask: it does not hold the loop open and needs no bookkeeping.
  */
 export function yieldToMain(): Promise<void> {
   const scheduler = (globalThis as { scheduler?: { yield?: () => Promise<void> } }).scheduler;
   if (scheduler && typeof scheduler.yield === "function") {
     return scheduler.yield();
+  }
+  if (!hasDom && typeof setImmediate === "function") {
+    return new Promise<void>((resolve) => setImmediate(resolve));
   }
   return new Promise<void>((resolve) => {
     pending.push(resolve);

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @file Performance regression guards.
+ *
+ * These assert CONSEQUENCES of the throttling rewrite, not its presence:
+ *   - indexing and querying finish in a time that sleep-based throttling could
+ *     not possibly achieve, so reintroducing it turns these red;
+ *   - the memoized popCount stays correct across every mutation path, so the
+ *     speedup cannot silently corrupt similarity scores.
+ *
+ * The bug being guarded: processDocument() previously slept 16ms per 10-word
+ * chunk, making a single 1,000-word note take ~1.6s, and getSimilarDocuments()
+ * slept 16ms per 10 comparisons.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BloomFilter } from '../src/bloom';
+import { MultiResolutionBloomFilterProvider } from '../src/multi-bloom';
+
+function makeDoc(seed: number, words: number): string {
+  const out: string[] = [];
+  for (let i = 0; i < words; i++) out.push(`term${(seed * 31 + i * 17) % 900}`);
+  return out.join(' ');
+}
+
+function makeProvider(): MultiResolutionBloomFilterProvider {
+  const vault = {
+    getMarkdownFiles: () => [],
+    cachedRead: () => Promise.resolve(''),
+    adapter: {
+      exists: () => Promise.resolve(false),
+      read: () => Promise.resolve(''),
+      write: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+    },
+    configDir: '/mock/config',
+  } as never;
+
+  return new MultiResolutionBloomFilterProvider(vault, {
+    ngramSizes: [3],
+    bloomSizes: [2048],
+    hashFunctions: [3],
+    similarityThreshold: 0.1,
+    useWordBasedCandidates: true,
+  });
+}
+
+describe('BloomFilter.popCount memoization', () => {
+  it('matches a fresh count and tracks add()', () => {
+    const f = new BloomFilter(1024, 3);
+    expect(f.popCount()).toBe(0);
+
+    f.add('alpha');
+    const afterFirst = f.popCount();
+    expect(afterFirst).toBeGreaterThan(0);
+
+    // Memo must invalidate on further writes, not return the stale value.
+    f.add('beta');
+    expect(f.popCount()).toBeGreaterThanOrEqual(afterFirst);
+
+    // Independent recount of the same bits.
+    let manual = 0;
+    const bits = f.getBitArray();
+    for (let i = 0; i < bits.length; i++) {
+      let v = bits[i];
+      while (v) { manual += v & 1; v >>>= 1; }
+    }
+    expect(f.popCount()).toBe(manual);
+  });
+
+  it('invalidates on clear(), deserialize() and setBitArray()', () => {
+    const f = new BloomFilter(1024, 3);
+    for (const w of ['a', 'b', 'c', 'd']) f.add(w);
+    expect(f.popCount()).toBeGreaterThan(0);
+
+    f.clear();
+    expect(f.popCount()).toBe(0);
+
+    const src = new BloomFilter(1024, 3);
+    for (const w of ['x', 'y', 'z']) src.add(w);
+    const expected = src.popCount();
+
+    f.deserialize({ size: 1024, hashFunctions: 3, bitArray: Array.from(src.getBitArray()) });
+    expect(f.popCount()).toBe(expected);
+
+    const g = new BloomFilter(1024, 3);
+    g.popCount(); // prime the memo at 0 before overwriting the array
+    g.setBitArray(new Uint32Array(src.getBitArray()));
+    expect(g.popCount()).toBe(expected);
+  });
+
+  it('similarity is unchanged by memoization (repeat calls agree)', () => {
+    const a = new BloomFilter(2048, 3);
+    const b = new BloomFilter(2048, 3);
+    for (let i = 0; i < 200; i++) { a.add(`w${i}`); b.add(`w${i * 2}`); }
+
+    const first = a.similarity(b);
+    expect(a.similarity(b)).toBe(first);
+
+    // A mutation must move the score, proving the memo is not pinning it.
+    for (let i = 0; i < 200; i++) b.add(`w${i}`);
+    expect(a.similarity(b)).not.toBe(first);
+  });
+});
+
+describe('throttling does not idle', () => {
+  it('indexes a long document far faster than per-chunk sleeping allowed', async () => {
+    const provider = makeProvider();
+    const words = 2000; // 200 chunks of 10 -> 200 x 16ms = 3.2s under the old code
+
+    const start = performance.now();
+    await provider.processDocument('long.md', makeDoc(1, words));
+    const elapsed = performance.now() - start;
+
+    // Measured ~25ms. 200 chunk sleeps at 16ms would be ~3200ms.
+    expect(elapsed).toBeLessThan(300);
+  });
+
+  it('indexes many documents without fixed per-document sleeps', async () => {
+    const provider = makeProvider();
+    const docs = 60;
+
+    const start = performance.now();
+    for (let i = 0; i < docs; i++) {
+      await provider.processDocument(`doc${i}.md`, makeDoc(i, 120));
+    }
+    const elapsed = performance.now() - start;
+
+    // Old code: >=53ms of fixed sleeps per document, i.e. >3s for 60 docs,
+    // before counting the per-chunk sleeps.
+    // Measured ~75ms for 60 docs.
+    expect(elapsed).toBeLessThan(600);
+  });
+
+  it('queries without sleeping per batch of comparisons', async () => {
+    const provider = makeProvider();
+    const docs = 200;
+    for (let i = 0; i < docs; i++) {
+      await provider.processDocument(`doc${i}.md`, makeDoc(i, 60));
+    }
+
+    const start = performance.now();
+    const results = await provider.getSimilarDocuments('doc0.md', 10);
+    const elapsed = performance.now() - start;
+
+    // Old code: 200/10 = 20 yields x 16ms = 320ms of pure sleep minimum.
+    expect(elapsed).toBeLessThan(250);
+    expect(Array.isArray(results)).toBe(true);
+  });
+});

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @file Tests for the cooperative scheduling primitives.
+ *
+ * These guard the property that replaced sleep-based CPU throttling: the plugin
+ * must hand control back to the event loop without idling. A regression here
+ * (e.g. reintroducing `setTimeout(resolve, 16)`) makes these fail on wall clock.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TimeSlicer, yieldToMain, DEFAULT_SLICE_BUDGET_MS } from '../src/scheduler';
+
+const busyWaitMs = (ms: number) => {
+  const until = performance.now() + ms;
+  // eslint-disable-next-line no-empty
+  while (performance.now() < until) {}
+};
+
+describe('yieldToMain', () => {
+  it('resolves', async () => {
+    await expect(yieldToMain()).resolves.toBeUndefined();
+  });
+
+  it('does not sleep: 200 yields cost far less than 200 timer ticks', async () => {
+    const start = performance.now();
+    for (let i = 0; i < 200; i++) await yieldToMain();
+    const elapsed = performance.now() - start;
+
+    // The old throttle slept 16ms per yield, i.e. >3000ms for this loop. Even
+    // setTimeout(0) is clamped to ~1ms/yield (>200ms). A real yield is ~0.02ms.
+    expect(elapsed).toBeLessThan(150);
+  });
+
+  it('defers past the microtask queue, so the event loop can turn', async () => {
+    const order: string[] = [];
+
+    const yielded = yieldToMain().then(() => order.push('yield'));
+    // Microtasks queued after the yield still run first: the yield is a task,
+    // not a promise continuation. A microtask-only "yield" would starve the
+    // event loop and never let the UI paint.
+    Promise.resolve().then(() => order.push('microtask'));
+
+    await yielded;
+
+    expect(order).toEqual(['microtask', 'yield']);
+  });
+});
+
+describe('TimeSlicer', () => {
+  it('does not yield while inside the budget', async () => {
+    const slicer = new TimeSlicer(50);
+    for (let i = 0; i < 100; i++) await slicer.tick();
+    expect(slicer.yieldCount).toBe(0);
+  });
+
+  it('yields once the budget is exceeded, then starts a fresh slice', async () => {
+    const slicer = new TimeSlicer(5);
+    busyWaitMs(8);
+    await slicer.tick();
+    expect(slicer.yieldCount).toBe(1);
+
+    // Budget was reset by the yield, so an immediate tick must not yield again.
+    await slicer.tick();
+    expect(slicer.yieldCount).toBe(1);
+  });
+
+  it('yields repeatedly across a long run, scaling with elapsed work', async () => {
+    const budget = 10;
+    const slicer = new TimeSlicer(budget);
+    const workMs = 2;
+    const iterations = 40; // ~80ms of work -> ~8 budget windows
+
+    for (let i = 0; i < iterations; i++) {
+      busyWaitMs(workMs);
+      await slicer.tick();
+    }
+
+    // The guarantee is that yields track elapsed time rather than a fixed
+    // operation count. Bounds are loose so a slow CI box cannot flake it.
+    const windows = (iterations * workMs) / budget;
+    expect(slicer.yieldCount).toBeGreaterThanOrEqual(Math.floor(windows / 3));
+    expect(slicer.yieldCount).toBeLessThanOrEqual(iterations);
+  });
+
+  it('a yielding tick hands off without sleeping', async () => {
+    // Budget 0 forces every tick down the yielding path, which is the exact
+    // line a regression would replace with `setTimeout(resolve, 16)`.
+    const slicer = new TimeSlicer(0);
+    const start = performance.now();
+    for (let i = 0; i < 200; i++) await slicer.tick();
+    const elapsed = performance.now() - start;
+
+    expect(slicer.yieldCount).toBe(200);
+    // 200 sleeping ticks would cost >3000ms; 200 real yields cost single-digit ms.
+    expect(elapsed).toBeLessThan(150);
+  });
+
+  it('defaults to a sub-frame budget', () => {
+    expect(DEFAULT_SLICE_BUDGET_MS).toBeLessThanOrEqual(16);
+    expect(DEFAULT_SLICE_BUDGET_MS).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Indexing and querying spent almost all of their wall-clock **asleep**. Stacked on #19 (needs its test fix to run the suite).

## The bug

The CPU throttle yielded a *fixed duration* every *N operations*:

| Site | Throttle |
|---|---|
| `processDocument()` | 16ms per **10-word chunk**, plus ~53ms of fixed sleeps per document |
| `getSimilarDocuments()` | 16ms per **10 comparisons** |
| `initialize()` | 20ms per 3-file batch + 10ms per 5 files |

A 1,000-word note took **~1.6s to index**, essentially all of it idle. Modelled over a 5,000-file vault: **~43s of sleeping during indexing** and **up to 8s per query** — against ~6ms of actual comparison work for 5,000 filters.

Sleeping doesn't make the UI more responsive than yielding does; it just stops using the CPU. What responsiveness needs is never holding the main thread longer than a frame.

## The fix

`src/scheduler.ts`:

- **`yieldToMain()`** — `scheduler.yield()` where available, else a MessageChannel round-trip. Measured **~0.02ms**, vs ~1.2ms for `setTimeout(0)` (nested timers are clamped to 4ms in Electron) and ~17ms for `setTimeout(16)`.
- **`TimeSlicer`** — yields only once the main thread has been held past an 8ms budget. Short passes never yield; long ones stay frame-friendly. Budgeting by *elapsed time* also adapts to the machine, which a fixed operation count cannot: 10 comparisons take microseconds, 10 file reads take milliseconds.

### Results

**Test suite: 50.51s → 1.60s.** `tests/benchmark.test.ts` alone, which simulates small/medium/large vault indexing, goes **47,743ms → 269ms**.

## Also in the similarity hot path

- **`BloomFilter.popCount()` is memoized.** Each filter's own bit count was recomputed for *both sides of every pairwise comparison*, so a query made O(candidates) redundant passes over the same query filter. The union is now derived as `|A|+|B|-|A∩B|` instead of a second popcount pass. Every write path resets the memo.
- **The debug string in `similarity()` is now guarded.** `logIfDebugModeEnabled()` checks the flag *inside* the function, so the caller's template literal — six `toFixed()` calls over eight interpolations — was allocated on **every comparison with debug mode off**.

Together: **3.8x** on the isolated similarity loop, verified **bit-identical** to the previous implementation across 300 filter pairs.

## Deliberately unchanged

`CHUNK_SIZE` in `processDocument` stays at 10, now with a comment explaining why: `extractWords()` derives bigrams *within* each chunk and caps them *per chunk*, so chunk boundaries are part of what lands in the filter. Resizing chunks silently changes every similarity score in every user's vault.

## Guards

Both new test files were **verified to fail against the regressions** before being committed:

- reintroducing `setTimeout` in `TimeSlicer.tick()` → fails the yield-cost assertion
- restoring the per-chunk sleep → fails the indexing guard at **2199ms against a 300ms bound**

Thresholds are set from measured values (~25ms, ~75ms, ~120ms), not guessed. My first draft of these guards *passed* against a reintroduced sleep — they were too loose, and were tightened until they actually caught it. `popCount` invalidation is covered for `add`/`clear`/`deserialize`/`setBitArray`.

## Verification

- `npm run build` — passes
- `npm run test:run` — **125 passing** (up from 111)
- `npm audit` — 0 vulnerabilities

## Separate finding: the similarity algorithm is wrong for long notes

Not fixed here, because it changes every score in every user's vault and invalidates cached filters — your call.

`similarity()` multiplies the Jaccard score by `(1 - saturation)²` once a filter exceeds 40% occupancy. Measured **self-similarity, a document against an identical copy** (4096-bit filter):

| words | saturation | score | correct |
|---|---|---|---|
| 400 | 35.9% | 1.0000 | 1.0 |
| 800 | 54.2% | **0.2098** | 1.0 |
| 1600 | 77.8% | **0.0491** | 1.0 |
| 3200 | 92.2% | **0.0061** | 1.0 |

A 3,200-word note is scored 99.4% *dissimilar from itself*, so long notes are systematically excluded from results. It also inverts ranking: identical 1,600-word notes score 0.049 while merely-similar 4-word notes score 0.556.

Saturation is a real problem — the penalty is the wrong fix. The standard correction is the Swamidass–Baldi cardinality estimator, `n̂ = -(m/k)·ln(1 - t/m)`, then `J = (n̂A + n̂B - n̂U)/n̂U`. Tested against the same corpus: self-similarity **1.0000 at every length**, discrimination preserved (0.4465 related vs 0.0000 unrelated), and long duplicates correctly rank above short coincidental matches.

Related dead code, same area: `extractWords()` sets `isLowFidelity = wordSet.size > 500`, but it only ever sees one 10-word chunk (≤19 tokens), so it is **always false** and `MAX_BIGRAMS_*_LARGE` are unreachable. The `MAX_BIGRAMS_*` caps (100/200) never bind either, since a chunk yields at most 9 bigrams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Does removing the sleeps hog the CPU?

Fair concern, so it was measured rather than argued. Indexing 1,200 docs × 400 words (48,000 chunks, ~1.4s of real work) with a 16ms metronome sampling event-loop lag — how late that metronome fires is how long a click, keystroke or repaint would be stuck behind indexing:

| strategy | duration | frames delivered | median late | max late |
|---|---|---|---|---|
| blocking (no yield) | 1.43s | **0** | — | — |
| time-sliced 2ms | 1.35s | 81 | 0.5ms | 1.6ms |
| time-sliced 4ms | 1.35s | 82 | 0.3ms | 0.6ms |
| **time-sliced 8ms** (shipped) | 1.34s | 82 | **0.2ms** | **0.3ms** |
| time-sliced 16ms | 1.33s | 82 | 0.1ms | 0.2ms |
| time-sliced 50ms | 1.37s | 27 | 34.2ms | 34.5ms |

**Blocking delivers zero frames** — that is what hogging the CPU actually looks like, a UI frozen solid for 1.4s. At the shipped 8ms budget every frame lands, 0.2ms late at the median, for the *same total duration* as blocking. Yielding is free. The 50ms row shows the failure mode the budget exists to prevent.

So CPU *utilisation* does go up — the work now runs instead of idling, which is the point — but the main thread is never held longer than a frame, and the window of elevated CPU is 40x–500x shorter. For this workload the old throttle would have taken **12.8 minutes**.

Two honest caveats: this is Node with `setImmediate`, so a real renderer doing actual paint work will show higher lateness than 0.2ms (the structural property — bounded sub-frame holds — is what carries over); and sustained high CPU for seconds draws more instantaneous power than trickling for a minute, even though total energy for the same work is lower.

### Two bugs found while measuring

A Node `MessagePort` is an active libuv handle, so the module-level `MessageChannel` kept the event loop alive forever — any Node process that imported `scheduler.ts` and yielded once would never exit. Missed initially because vitest force-exits workers and Electron runs forever; it surfaced as a benchmark harness hanging until killed.

`unref()`ing the port fixes the hang, but then an in-flight yield cannot keep the loop alive long enough to be delivered and the await never settles. Referencing only while a yield is outstanding works, but the ref/unref pair costs more than the yield itself — it took the 60-document guard from ~75ms to 670ms and broke a word-candidate test.

The primitive is now picked per environment: `scheduler.yield()` where available, `MessageChannel` in any renderer, `setImmediate` under bare Node.
