### PR TITLE
Fix similarity scoring so long notes are not excluded from results

### DIFF
--- a/src/bloom.ts
+++ b/src/bloom.ts
@@ -273,40 +273,71 @@ export class BloomFilter {
       return 0;
     }
 
-    // Calculate raw Jaccard similarity
-    let similarity = unionBits === 0 ? 0 : intersectionBits / unionBits;
+    // Jaccard over the SET CARDINALITIES, not over the raw bits.
+    //
+    // Bit-level Jaccard is biased: as a filter fills, distinct items collide on
+    // shared bits, so the bit counts understate the sets and the ratio drifts
+    // toward 1 for every pair. This previously carried an ad-hoc correction —
+    // multiply by (1 - saturation)^2 past 40% occupancy — which destroyed true
+    // positives instead of debiasing anything: a 3,200-word note scored 0.006
+    // against an identical copy, so long notes were effectively excluded from
+    // results, and identical long notes ranked below barely-related short ones.
+    //
+    // Swamidass & Baldi's estimator inverts the fill process to recover how many
+    // distinct items a filter must have held, which stays accurate deep into
+    // saturation and needs no fudge factor:
+    //
+    //   n̂(t) = -(m/k) * ln(1 - t/m)     for t bits set of m, with k hashes
+    //   |A ∩ B| = n̂(A) + n̂(B) - n̂(A ∪ B)
+    //   J       = |A ∩ B| / |A ∪ B|
+    const nThis = this.estimateCardinality(thisBits);
+    const nOther = this.estimateCardinality(otherBits);
+    const nUnion = this.estimateCardinality(unionBits);
 
-    // Check for filter saturation (too many bits set)
-    const thisRatio = thisBits / this.size;
-    const otherRatio = otherBits / this.size;
-
-    // If either filter is highly saturated (>40% bits set), scale down similarity
-    // This reduces false positives when bloom filters become saturated
-    if (thisRatio > 0.4 || otherRatio > 0.4) {
-      // Scale down more aggressively as saturation increases
-      const saturationFactor = Math.max(thisRatio, otherRatio);
-      // Apply polynomial scaling (stronger than logarithmic)
-      similarity = similarity * Math.pow(1 - saturationFactor, 2);
+    // A completely full filter carries no information: n̂ diverges, and every
+    // document would look identical to every other.
+    if (!Number.isFinite(nUnion) || nUnion <= 0) {
+      logIfDebugModeEnabled(`Filter saturated to capacity (${unionBits}/${this.size} bits); cannot estimate similarity`);
+      return 0;
     }
+
+    const intersectionEstimate = Math.max(0, nThis + nOther - nUnion);
+    const similarity = Math.min(1, intersectionEstimate / nUnion);
 
     // Guarded: this runs once per candidate document, so building the message
     // unconditionally would allocate a multi-line string and run six toFixed()
     // calls on every comparison even with debug mode off.
     if (isDebugMode()) {
-      const rawSimilarity = unionBits === 0 ? 0 : intersectionBits / unionBits;
       logIfDebugModeEnabled(
         `Similarity details:
-      - Filter 1: ${thisBits} bits set (${(thisRatio * 100).toFixed(1)}% of capacity)
-      - Filter 2: ${otherBits} bits set (${(otherRatio * 100).toFixed(1)}% of capacity)
-      - Intersection: ${intersectionBits} bits
-      - Union: ${unionBits} bits
+      - Filter 1: ${thisBits} bits set (${((thisBits / this.size) * 100).toFixed(1)}% of capacity), ~${nThis.toFixed(0)} items
+      - Filter 2: ${otherBits} bits set (${((otherBits / this.size) * 100).toFixed(1)}% of capacity), ~${nOther.toFixed(0)} items
+      - Intersection: ${intersectionBits} bits, ~${intersectionEstimate.toFixed(0)} items
+      - Union: ${unionBits} bits, ~${nUnion.toFixed(0)} items
       - Items in filter 1: ${this.addedItems.size}
       - Items in filter 2: ${other.addedItems.size}
-      - Raw similarity: ${(rawSimilarity * 100).toFixed(2)}%`
+      - Similarity: ${(similarity * 100).toFixed(2)}%`
       );
     }
 
     return similarity;
+  }
+
+  /**
+   * Estimate how many distinct items were added, given how many bits are set.
+   *
+   * Inverts the expected fill of a bloom filter: each of the k hashes per item
+   * lands uniformly, so after n items a given bit is still clear with
+   * probability (1 - 1/m)^(kn). Solving for n gives the Swamidass-Baldi
+   * estimator below. Returns Infinity for a filter at capacity, where the
+   * inversion has no solution.
+   *
+   * @param bitsSet Number of bits set in the filter (or in a union of filters)
+   */
+  private estimateCardinality(bitsSet: number): number {
+    if (bitsSet <= 0) return 0;
+    if (bitsSet >= this.size) return Infinity;
+    return -(this.size / this.hashFunctions) * Math.log(1 - bitsSet / this.size);
   }
 
   /**

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -112,8 +112,9 @@ describe('throttling does not idle', () => {
     await provider.processDocument('long.md', makeDoc(1, words));
     const elapsed = performance.now() - start;
 
-    // Measured ~25ms. 200 chunk sleeps at 16ms would be ~3200ms.
-    expect(elapsed).toBeLessThan(300);
+    // Measured ~25ms; 200 chunk sleeps at 16ms measured 2199ms. Bound sits
+    // between the two with room for a loaded CI box.
+    expect(elapsed).toBeLessThan(800);
   });
 
   it('indexes many documents without fixed per-document sleeps', async () => {
@@ -134,7 +135,7 @@ describe('throttling does not idle', () => {
 
   it('queries without sleeping per batch of comparisons', async () => {
     const provider = makeProvider();
-    const docs = 200;
+    const docs = 400;
     for (let i = 0; i < docs; i++) {
       await provider.processDocument(`doc${i}.md`, makeDoc(i, 60));
     }
@@ -143,8 +144,9 @@ describe('throttling does not idle', () => {
     const results = await provider.getSimilarDocuments('doc0.md', 10);
     const elapsed = performance.now() - start;
 
-    // Old code: 200/10 = 20 yields x 16ms = 320ms of pure sleep minimum.
-    expect(elapsed).toBeLessThan(250);
+    // Old code: 400/10 = 40 yields x 16ms = 640ms of pure sleep minimum, so a
+    // 450ms bound still catches it with margin for a slow box.
+    expect(elapsed).toBeLessThan(450);
     expect(Array.isArray(results)).toBe(true);
   });
 });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -25,9 +25,10 @@ describe('yieldToMain', () => {
     for (let i = 0; i < 200; i++) await yieldToMain();
     const elapsed = performance.now() - start;
 
-    // The old throttle slept 16ms per yield, i.e. >3000ms for this loop. Even
-    // setTimeout(0) is clamped to ~1ms/yield (>200ms). A real yield is ~0.02ms.
-    expect(elapsed).toBeLessThan(150);
+    // The old throttle slept 16ms per yield, i.e. >3400ms for this loop. A real
+    // yield is ~0.02ms, so the bound is deliberately loose: it only has to sit
+    // below "is this sleeping", not pin the fast path, or it flakes under load.
+    expect(elapsed).toBeLessThan(500);
   });
 
   it('defers past the microtask queue, so the event loop can turn', async () => {
@@ -90,8 +91,8 @@ describe('TimeSlicer', () => {
     const elapsed = performance.now() - start;
 
     expect(slicer.yieldCount).toBe(200);
-    // 200 sleeping ticks would cost >3000ms; 200 real yields cost single-digit ms.
-    expect(elapsed).toBeLessThan(150);
+    // 200 sleeping ticks would cost >3200ms; 200 real yields cost single-digit ms.
+    expect(elapsed).toBeLessThan(500);
   });
 
   it('defaults to a sub-frame budget', () => {

--- a/tests/similarity-correctness.test.ts
+++ b/tests/similarity-correctness.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @file Correctness guards for the similarity score.
+ *
+ * The bug these exist for: similarity() used to multiply Jaccard by
+ * (1 - saturation)^2 once a filter passed 40% occupancy. That is not a debiasing
+ * correction, it is a penalty, and it destroyed true positives — a 3,200-word
+ * note scored 0.0061 against an identical copy, so long notes were effectively
+ * excluded from results, and identical long notes ranked BELOW barely-related
+ * short ones.
+ *
+ * The invariant that catches it: a document is always perfectly similar to
+ * itself, at every document length. Any length-dependent scoring fudge breaks
+ * this immediately.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BloomFilter } from '../src/bloom';
+import { SingleBloomFilter } from '../src/multi-bloom';
+
+const CHUNK = 10; // must match processDocument's chunking
+
+function indexDoc(words: string[], size = 4096): SingleBloomFilter {
+  const f = new SingleBloomFilter([3], [size], [3]);
+  for (let i = 0; i < words.length; i += CHUNK) {
+    f.addText(words.slice(i, i + CHUNK).join(' '));
+  }
+  return f;
+}
+
+const distinctWords = (n: number) => Array.from({ length: n }, (_, i) => `w${i}`);
+
+function saturation(f: SingleBloomFilter, size: number): number {
+  const a = f.getBitArray();
+  let c = 0;
+  for (let i = 0; i < a.length; i++) { let v = a[i]; while (v) { c += v & 1; v >>>= 1; } }
+  return c / size;
+}
+
+describe('self-similarity is length-independent', () => {
+  // 800+ words push a 4096-bit filter past the old 40% penalty threshold.
+  for (const n of [100, 400, 800, 1600, 3200]) {
+    it(`a ${n}-word document is ~1.0 similar to an identical copy`, () => {
+      const a = indexDoc(distinctWords(n));
+      const b = indexDoc(distinctWords(n));
+      expect(a.similarity(b)).toBeGreaterThan(0.95);
+    });
+  }
+
+  it('holds even when the filter is heavily saturated', () => {
+    const a = indexDoc(distinctWords(3200));
+    expect(saturation(a, 4096)).toBeGreaterThan(0.5); // the regime that was broken
+    expect(a.similarity(indexDoc(distinctWords(3200)))).toBeGreaterThan(0.95);
+  });
+});
+
+describe('ranking is not inverted by document length', () => {
+  it('identical long documents outrank merely-similar short ones', () => {
+    const longA = indexDoc(distinctWords(1600));
+    const longB = indexDoc(distinctWords(1600));
+    const shortA = indexDoc(['alpha', 'beta', 'gamma', 'delta']);
+    const shortB = indexDoc(['alpha', 'beta', 'gamma', 'epsilon']);
+
+    // Previously 0.0491 vs 0.5556 — backwards.
+    expect(longA.similarity(longB)).toBeGreaterThan(shortA.similarity(shortB));
+  });
+});
+
+describe('discrimination still works', () => {
+  const cooking = 'pasta tomato garlic olive oil basil simmer sauce recipe kitchen boil pan salt pepper onion'.split(' ');
+  const baking = 'pizza tomato garlic olive oil basil oven dough recipe kitchen bake cheese salt pepper onion'.split(' ');
+  const physics = 'quantum electron proton neutron wavefunction hamiltonian eigenvalue operator spin lattice photon boson'.split(' ');
+
+  it('related documents score above unrelated ones', () => {
+    const a = indexDoc(cooking);
+    const related = a.similarity(indexDoc(baking));
+    const unrelated = a.similarity(indexDoc(physics));
+
+    expect(related).toBeGreaterThan(unrelated);
+    expect(related).toBeGreaterThan(0.1);
+  });
+
+  it('disjoint documents do not score as similar', () => {
+    expect(indexDoc(cooking).similarity(indexDoc(physics))).toBeLessThan(0.1);
+  });
+});
+
+describe('score bounds and degenerate inputs', () => {
+  it('never exceeds 1 or drops below 0', () => {
+    for (const n of [20, 200, 900, 2500]) {
+      const s = indexDoc(distinctWords(n)).similarity(indexDoc(distinctWords(n)));
+      expect(s).toBeGreaterThanOrEqual(0);
+      expect(s).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('returns 0 for a filter saturated to capacity', () => {
+    // Every bit set: the cardinality estimator has no solution there, and every
+    // document would otherwise look identical to every other.
+    const a = new BloomFilter(256, 3);
+    const b = new BloomFilter(256, 3);
+    a.setBitArray(new Uint32Array(256 / 32).fill(0xffffffff));
+    b.setBitArray(new Uint32Array(256 / 32).fill(0xffffffff));
+    expect(a.similarity(b)).toBe(0);
+  });
+
+  it('returns 0 for documents too small to compare', () => {
+    const tiny = new BloomFilter(1024, 3);
+    const other = new BloomFilter(1024, 3);
+    for (let i = 0; i < 50; i++) other.add(`w${i}`);
+    expect(tiny.similarity(other)).toBe(0); // fewer than 5 bits set
+  });
+
+  it('returns 0 for mismatched filter sizes', () => {
+    const a = new BloomFilter(1024, 3);
+    const b = new BloomFilter(2048, 3);
+    for (let i = 0; i < 50; i++) { a.add(`w${i}`); b.add(`w${i}`); }
+    expect(a.similarity(b)).toBe(0);
+  });
+});


### PR DESCRIPTION
Long notes were being excluded from their own related-notes results.

## The bug

`similarity()` multiplied the Jaccard score by `(1 - saturation)²` once a filter passed 40% occupancy. That is a penalty, not a correction, and it destroyed true positives. Measured **self-similarity — a document against an identical copy** (4096-bit filter):

| words | saturation | before | after |
|---|---|---|---|
| 400 | 35.9% | 1.0000 | 1.0000 |
| 800 | 54.2% | **0.2098** | 1.0000 |
| 1600 | 77.8% | **0.0491** | 1.0000 |
| 3200 | 92.2% | **0.0061** | 1.0000 |

A 3,200-word note scored **99.4% dissimilar from itself**. Since `getSimilarDocuments()` sorts by score and keeps the top N, long notes were systematically dropped. It also inverted ranking: identical 1,600-word notes scored 0.049 while merely-similar 4-word notes scored 0.556.

## The fix

Saturation is a real problem — as a filter fills, distinct items collide on shared bits, so bit counts understate the sets and bit-level Jaccard drifts toward 1 for every pair. The answer is to **debias the estimate**, not punish the score.

Swamidass & Baldi invert the expected fill to recover how many distinct items a filter must have held:

```
n̂(t) = -(m/k) · ln(1 - t/m)        t bits set of m, with k hashes
|A ∩ B| = n̂(A) + n̂(B) - n̂(A ∪ B)
J       = |A ∩ B| / |A ∪ B|
```

This stays accurate deep into saturation and needs no fudge factor. A filter at full capacity carries no information (n̂ diverges, and every document would look identical to every other), so that case returns 0 explicitly rather than 1.

### Discrimination is unaffected

Related 0.4465 vs unrelated 0.0000 on the same corpus as before. End to end, a 1,500-word note now ranks:

```
100.0%  long-duplicate.md      <- was ~5%, buried below unrelated notes
  7.8%  long-unrelated.md
  0.5%  short-note.md
```

Correct order, sensible magnitudes.

## No reindexing needed

The on-disk cache stores **bit arrays**, which are unchanged — only the scoring function changed. The in-memory `similarityCache` holds scores but has a 5-minute TTL, so it self-heals. (I said in #20 that this would invalidate cached filters; that was wrong, and it's why no cache-version bump is included here.)

## Guards

`tests/similarity-correctness.test.ts`, **verified to fail against the old penalty before being committed** — 5 failures at exactly 0.2098, 0.0491, 0.0061 and the 0.049-vs-0.556 inversion.

The load-bearing invariant is that **a document is ~1.0 similar to itself at every length**, which any length-dependent scoring fudge breaks immediately. Bounds, capacity saturation, too-small documents, and size mismatch are all covered.

## Also: fixes flaky perf guards from #20

The thresholds I added in #20 were set just above measured values and flaked under machine load — 194ms against a 150ms bound, 655ms against 600ms. They now sit between the real cost and the regression cost, re-verified to still catch a reintroduced sleep at **2187ms against 800ms** and **3415ms against 500ms**. Suite passed three consecutive runs.

## Verification

- `npm run build` — passes
- `npm run test:run` — **138 passing** (up from 125), stable across 3 runs
- `npm audit` — 0 vulnerabilities

Note: `npx eslint src/bloom.ts` reports 4 errors at lines 388–609. Those are pre-existing and unrelated to this change (part of the 98 pre-existing errors noted in #19); the new test file is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
