### PR TITLE
Make batching a yield interval, not a scoring input

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,6 +55,12 @@ export const BATCH_PROCESSING = {
   PROCESS_INTERVAL_MS: 2000,
   /** Small batch size for UI responsiveness */
   SMALL_BATCH_SIZE: 3,
+  /**
+   * Terms hashed into a bloom filter between yields. Purely a yield interval:
+   * tokenization happens once per document before batching, so changing this
+   * cannot change what lands in the filter (see chunking-invariance.test.ts).
+   */
+  TOKEN_BATCH_SIZE: 512,
   /** Maximum initial index size */
   MAX_INITIAL_INDEX_SIZE: 1000,
   /** Percentage of vault for initial indexing */
@@ -165,8 +171,12 @@ export const WORD_INDEX = {
  * Cache and version constants
  */
 export const CACHE = {
-  /** Current cache version */
-  VERSION: 1,
+  /**
+   * Current cache version. Bumped to 2: tokenization moved from per-10-word
+   * chunk to whole-document, so v1 filters hold a different term set and cannot
+   * be compared against freshly built ones. A mismatch forces a rebuild.
+   */
+  VERSION: 2,
   /** Cache directory relative path */
   RELATIVE_PATH: '/plugins/obsidian-related-notes/',
   /** Cache file name */

--- a/src/multi-bloom.ts
+++ b/src/multi-bloom.ts
@@ -99,18 +99,42 @@ export class SingleBloomFilter {
    */
   addText(text: string): void {
     this.addedItems.add(text);
+    this.addPreparedTokens(this.prepareTokens(text));
+  }
 
-    // Extract words from text
-    const words = this.extractWords(text);
+  /**
+   * Tokenize a document into exactly the terms that will enter the filter.
+   *
+   * Split out from addText so indexing can be time-sliced without the slicing
+   * changing what gets indexed. Bigram construction, the bigram cap and CJK
+   * detection are all whole-document properties: deriving them from a fragment
+   * makes the fragment size part of the scoring. Callers that need to yield
+   * should call this once per document, then feed the result to
+   * addPreparedTokens in batches.
+   *
+   * @param text Full document text
+   * @returns Deduplicated terms, in insertion order
+   */
+  prepareTokens(text: string): string[] {
+    return Array.from(this.extractWords(text));
+  }
 
-    // Add each word to the bloom filter
-    for (const word of words) {
-      this.filter.add(word);
+  /**
+   * Add a slice of an already-tokenized document to the filter.
+   *
+   * Slicing here controls only when the caller may yield. Because the tokens
+   * were derived from the whole document up front, the union of every slice is
+   * identical however the slices are divided — which is the property that
+   * tests/chunking-invariance.test.ts pins.
+   *
+   * @param tokens Output of prepareTokens
+   * @param start Inclusive start index
+   * @param end Exclusive end index
+   */
+  addPreparedTokens(tokens: string[], start = 0, end = tokens.length): void {
+    for (let i = start; i < end; i++) {
+      this.filter.add(tokens[i]);
       this.itemCount++;
-    }
-
-    if (isDebugMode()) {
-      // Words added to bloom filter
     }
   }
 
@@ -892,19 +916,22 @@ export class MultiResolutionBloomFilterProvider implements SimilarityProvider {
     const processed = this.preprocessText(limitedText);
     await slicer.tick();
 
-    // Feed the filter in chunks so a very long document cannot hold the main
-    // thread, yielding only once a chunk has actually overrun the frame budget.
+    // Tokenize the WHOLE document once, then hash it in batches.
     //
-    // CHUNK_SIZE must not change: extractWords() derives bigrams within each
-    // chunk and caps them per chunk, so the chunk boundaries are part of what
-    // ends up in the filter. Resizing chunks would silently change similarity
-    // scores for every document.
-    const words = processed.split(/\s+/);
-    const CHUNK_SIZE = TIMING.MAX_OPERATIONS_BEFORE_YIELD;
+    // This used to slice the text into 10-word chunks and call addText() on each,
+    // which made the chunk size part of the scoring rather than just a yield
+    // interval: bigrams never spanned a chunk boundary (one in ten lost), the
+    // per-call bigram cap could never bind (a 10-word chunk yields at most 9
+    // bigrams against a cap of 100-200, so a long note produced several times
+    // the intended number), and extractWords()' own low-fidelity switch
+    // (wordSet.size > 500) could never fire because it only ever saw ~19 tokens.
+    //
+    // Splitting tokenization from insertion keeps every one of those decisions
+    // document-wide, so TOKEN_BATCH_SIZE now controls only when we yield.
+    const tokens = filter.prepareTokens(processed);
 
-    for (let i = 0; i < words.length; i += CHUNK_SIZE) {
-      const chunk = words.slice(i, i + CHUNK_SIZE).join(' ');
-      filter.addText(chunk);
+    for (let i = 0; i < tokens.length; i += BATCH_PROCESSING.TOKEN_BATCH_SIZE) {
+      filter.addPreparedTokens(tokens, i, Math.min(i + BATCH_PROCESSING.TOKEN_BATCH_SIZE, tokens.length));
       await slicer.tick();
     }
 

--- a/tests/chunking-invariance.test.ts
+++ b/tests/chunking-invariance.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @file Guards that batching is a yield interval, not a scoring input.
+ *
+ * The bug: processDocument() sliced text into 10-word chunks and called
+ * addText() on each. extractWords() derives bigrams within whatever text it is
+ * given and caps them per call, so the chunk size silently became part of what
+ * landed in the filter:
+ *
+ *   - bigrams never spanned a chunk boundary, losing one in ten;
+ *   - the bigram cap could never bind (9 bigrams per chunk against a cap of
+ *     100-200), so a long note produced several times the intended number;
+ *   - extractWords()' low-fidelity switch (wordSet.size > 500) could never fire,
+ *     because it only ever saw ~19 tokens, leaving MAX_BIGRAMS_*_LARGE dead.
+ *
+ * Tokenization is now done once per document, then hashed in batches. The
+ * invariant below is what makes the batch size safe to tune.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SingleBloomFilter, MultiResolutionBloomFilterProvider } from '../src/multi-bloom';
+import { BLOOM_FILTER, CACHE } from '../src/constants';
+
+function makeProvider(size = SIZE): MultiResolutionBloomFilterProvider {
+  const vault = {
+    getMarkdownFiles: () => [],
+    cachedRead: () => Promise.resolve(''),
+    adapter: {
+      exists: () => Promise.resolve(false),
+      read: () => Promise.resolve(''),
+      write: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+    },
+    configDir: '/mock/config/dir',
+  } as never;
+  return new MultiResolutionBloomFilterProvider(vault, {
+    ngramSizes: [3], bloomSizes: [size], hashFunctions: [3], similarityThreshold: 0.1,
+  });
+}
+
+const SIZE = 8192;
+
+const distinctWords = (n: number) => Array.from({ length: n }, (_, i) => `term${i}`);
+
+/** Index a document by tokenizing once, then inserting in batches of `batch`. */
+function indexInBatches(text: string, batch: number): SingleBloomFilter {
+  const f = new SingleBloomFilter([3], [SIZE], [3]);
+  const tokens = f.prepareTokens(text);
+  for (let i = 0; i < tokens.length; i += batch) {
+    f.addPreparedTokens(tokens, i, Math.min(i + batch, tokens.length));
+  }
+  return f;
+}
+
+/** The old behaviour: slice the TEXT, then tokenize each slice independently. */
+function indexByTextChunks(words: string[], chunk: number): SingleBloomFilter {
+  const f = new SingleBloomFilter([3], [SIZE], [3]);
+  for (let i = 0; i < words.length; i += chunk) {
+    f.addText(words.slice(i, i + chunk).join(' '));
+  }
+  return f;
+}
+
+const bitsOf = (f: SingleBloomFilter) => Array.from(f.getBitArray());
+const bigramsIn = (tokens: string[]) => tokens.filter((t) => t.includes(' '));
+
+describe('batch size does not affect filter contents', () => {
+  const text = distinctWords(900).join(' ');
+
+  it('every batch size produces an identical filter', () => {
+    const reference = bitsOf(indexInBatches(text, 1));
+    for (const batch of [7, 64, 512, 100_000]) {
+      expect(bitsOf(indexInBatches(text, batch))).toEqual(reference);
+    }
+  });
+
+  it('batched insertion matches a single addText of the whole document', () => {
+    const whole = new SingleBloomFilter([3], [SIZE], [3]);
+    whole.addText(text);
+    expect(bitsOf(indexInBatches(text, 512))).toEqual(bitsOf(whole));
+  });
+
+  it('the old text-chunking really did differ, so this is not a vacuous test', () => {
+    const words = distinctWords(900);
+    expect(bitsOf(indexByTextChunks(words, 10))).not.toEqual(bitsOf(indexInBatches(words.join(' '), 512)));
+  });
+});
+
+describe('bigrams span the whole document', () => {
+  const words = distinctWords(40);
+  const text = words.join(' ');
+
+  it('includes bigrams that cross the old 10-word chunk boundary', () => {
+    const tokens = new SingleBloomFilter([3], [SIZE], [3]).prepareTokens(text);
+    // term9 -> term10 straddled the first old chunk boundary.
+    expect(tokens).toContain('term9 term10');
+    expect(tokens).toContain('term19 term20');
+  });
+
+  it('produces one bigram per adjacent pair, not per-chunk fragments', () => {
+    const tokens = new SingleBloomFilter([3], [SIZE], [3]).prepareTokens(text);
+    // 40 words -> 39 adjacent pairs, all under the cap.
+    expect(bigramsIn(tokens)).toHaveLength(words.length - 1);
+  });
+});
+
+describe('the bigram cap and fidelity switch are now reachable', () => {
+  it('caps bigrams on a long document instead of scaling with length', () => {
+    const short = new SingleBloomFilter([3], [SIZE], [3]).prepareTokens(distinctWords(300).join(' '));
+    const long = new SingleBloomFilter([3], [SIZE], [3]).prepareTokens(distinctWords(3000).join(' '));
+
+    // Ten times the words must not mean ten times the bigrams.
+    expect(bigramsIn(long).length).toBeLessThan(bigramsIn(short).length * 10);
+    expect(bigramsIn(long).length).toBeLessThanOrEqual(BLOOM_FILTER.MAX_BIGRAMS_NON_CJK);
+  });
+
+  it('switches to the low-fidelity cap past 500 distinct words', () => {
+    // Under the threshold: the standard cap applies.
+    const under = new SingleBloomFilter([3], [SIZE], [3]).prepareTokens(distinctWords(400).join(' '));
+    expect(bigramsIn(under)).toHaveLength(BLOOM_FILTER.MAX_BIGRAMS_NON_CJK);
+
+    // Over it: MAX_BIGRAMS_NON_CJK_LARGE, previously unreachable code.
+    const over = new SingleBloomFilter([3], [SIZE], [3]).prepareTokens(distinctWords(600).join(' '));
+    expect(bigramsIn(over)).toHaveLength(BLOOM_FILTER.MAX_BIGRAMS_NON_CJK_LARGE);
+    expect(BLOOM_FILTER.MAX_BIGRAMS_NON_CJK_LARGE).toBeLessThan(BLOOM_FILTER.MAX_BIGRAMS_NON_CJK);
+  });
+});
+
+describe('processDocument actually uses whole-document tokenization', () => {
+  // Without this, every test above can pass while processDocument still slices
+  // text into chunks — the helper is correct but never called. Verified by
+  // reverting processDocument to per-chunk addText: these go red, the API-level
+  // tests above do not.
+  const DEFAULT_SIZE = BLOOM_FILTER.DEFAULT_FILTER_SIZE;
+
+  function filterFor(provider: MultiResolutionBloomFilterProvider, id: string): SingleBloomFilter {
+    const filters = (provider as unknown as { bloomFilters: Map<string, SingleBloomFilter> }).bloomFilters;
+    const f = filters.get(id);
+    if (!f) throw new Error(`no filter indexed for ${id}`);
+    return f;
+  }
+
+  it('produces the same filter as a single whole-document addText', async () => {
+    const text = distinctWords(300).join(' ');
+    const provider = makeProvider(DEFAULT_SIZE);
+    await provider.processDocument('doc.md', text);
+
+    // Same preprocessing the indexer applied, so only tokenization differs.
+    const processed = (provider as unknown as { preprocessText(t: string): string }).preprocessText(text);
+    const reference = new SingleBloomFilter([3], [DEFAULT_SIZE], [3]);
+    reference.addText(processed);
+
+    expect(bitsOf(filterFor(provider, 'doc.md'))).toEqual(bitsOf(reference));
+  });
+
+  it('indexes bigrams that straddle the old chunk boundaries', async () => {
+    const provider = makeProvider(DEFAULT_SIZE);
+    await provider.processDocument('doc.md', distinctWords(60).join(' '));
+    const filter = filterFor(provider, 'doc.md');
+
+    // Boundary-spanning pairs under per-chunk tokenization were never formed.
+    for (const bigram of ['term9 term10', 'term19 term20', 'term29 term30']) {
+      expect(filter.filter.contains(bigram)).toBe(true);
+    }
+    // Control: a pair that is not adjacent should not be present, which also
+    // shows the assertions above are not just bloom-filter false positives.
+    expect(filter.filter.contains('term3 term40')).toBe(false);
+  });
+});
+
+describe('the cache version forces stale filters to be rebuilt', () => {
+  // Changing tokenization changes what a filter holds, so a cache written by an
+  // older build must not be compared against freshly built filters. This is the
+  // half of the bump that actually protects users.
+  it('has been bumped past the pre-chunking-fix version', () => {
+    expect(CACHE.VERSION).toBeGreaterThan(1);
+  });
+
+  it('the real validator rejects an older cache and accepts a current one', () => {
+    const provider = makeProvider();
+    // validateCacheStructure is private; reached deliberately because this is the
+    // gate the bump relies on, and asserting version arithmetic instead would
+    // prove nothing about whether stale caches are actually discarded.
+    const validate = (cache: unknown) =>
+      (provider as unknown as { validateCacheStructure(c: unknown): { isValid: boolean; reason?: string } })
+        .validateCacheStructure(cache);
+
+    const shape = {
+      timestamp: Date.now(), // a zero timestamp is rejected separately, as too old
+      filters: {},
+      stats: {},
+      params: { ngramSizes: [3], hashFunctions: [3], similarityThreshold: 0.1 },
+    };
+
+    const stale = validate({ ...shape, version: CACHE.VERSION - 1 });
+    expect(stale.isValid).toBe(false);
+    expect(stale.reason).toMatch(/version mismatch/i);
+
+    expect(validate({ ...shape, version: CACHE.VERSION }).isValid).toBe(true);
+  });
+});
+
+describe('CJK detection is a whole-document decision', () => {
+  it('applies the CJK cap even when CJK text appears late in the document', () => {
+    // Under the old scheme only the chunks containing CJK saw hasCJK = true.
+    const asciiPrefix = distinctWords(600).join(' ');
+    const tokens = new SingleBloomFilter([3], [SIZE], [3]).prepareTokens(`${asciiPrefix} 日本語 の 文章`);
+    expect(bigramsIn(tokens)).toHaveLength(BLOOM_FILTER.MAX_BIGRAMS_CJK_LARGE);
+  });
+});

--- a/tests/multi-bloom.test.ts
+++ b/tests/multi-bloom.test.ts
@@ -10,6 +10,7 @@ import {
   calculateOptimalHashFunctions
 } from '../src/multi-bloom';
 import { WordBasedCandidateSelector } from '../src/word-index';
+import { CACHE } from '../src/constants';
 
 describe('Optimal Size Calculations', () => {
   describe('calculateOptimalBloomSize', () => {
@@ -367,7 +368,7 @@ describe('MultiResolutionBloomFilterProvider', () => {
         adapter: {
           exists: (path: string) => Promise.resolve(path.includes('.bloom-filter-cache.json')),
           read: (path: string) => Promise.resolve(JSON.stringify({
-            version: 1, // Current cache version
+            version: CACHE.VERSION, // track the constant, not a literal
             timestamp: Date.now(), // Fresh timestamp
             params: {
               ngramSizes: [3],
@@ -433,7 +434,7 @@ describe('MultiResolutionBloomFilterProvider', () => {
 
       // Simulate cache with actual document data
       const savedCache = {
-        version: 1,
+        version: CACHE.VERSION, // track the constant, not a literal
         timestamp: Date.now(),
         params: {
           ngramSizes: [3],

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -128,9 +128,10 @@ describe('throttling does not idle', () => {
     const elapsed = performance.now() - start;
 
     // Old code: >=53ms of fixed sleeps per document, i.e. >3s for 60 docs,
-    // before counting the per-chunk sleeps.
-    // Measured ~75ms for 60 docs.
-    expect(elapsed).toBeLessThan(600);
+    // before counting the per-chunk sleeps. The bound sits between the real
+    // cost and the regression cost, not just above the measured value — at 600ms
+    // this flaked under `npm ci` contention.
+    expect(elapsed).toBeLessThan(2000);
   });
 
   it('queries without sleeping per batch of comparisons', async () => {


### PR DESCRIPTION
The last item from the #19–#21 audit: a performance mechanism was silently deciding what went into the bloom filters.

## The bug

`processDocument()` sliced text into 10-word chunks and called `addText()` on each. `extractWords()` derives bigrams from whatever text it is handed, and caps them **per call**, so the chunk size became part of the scoring rather than just a yield interval:

- **Bigrams never spanned a chunk boundary** — one in ten lost.
- **The bigram cap could never bind.** A 10-word chunk yields at most 9 bigrams against a cap of 100–200, so a 1,000-word note produced ~900 bigrams where 200 were intended.
- **The low-fidelity switch was dead code.** `isLowFidelity = wordSet.size > 500` only ever saw ~19 tokens, leaving `MAX_BIGRAMS_NON_CJK_LARGE` and `MAX_BIGRAMS_CJK_LARGE` unreachable.
- **CJK detection ran per fragment**, so a document's cap depended on which chunk happened to contain CJK characters.

## The fix

Tokenize once per document, then hash the result in batches of `TOKEN_BATCH_SIZE`. Every decision above becomes whole-document, and the batch size controls only *when* we yield.

`SingleBloomFilter` gains `prepareTokens()` and `addPreparedTokens()`. `addText()` is unchanged for callers passing a full document — which is how the existing tests use it.

### Faster, too

Because the bigram cap now binds, there is less to hash. 200 documents indexed:

| words | per-chunk | whole-document |
|---|---|---|
| 60 | 68ms | 53ms |
| 400 | 550ms | 493ms |
| 2000 | 3449ms | **1551ms** |

## Cache version 1 → 2

Unlike the scoring change in #21, this alters what the filters *contain*, so a v1 cache cannot be compared against freshly built filters. The existing version gate discards it and reindexes. Users will see one reindex on upgrade.

## Guards

The load-bearing test is that **`processDocument`'s filter must equal a single whole-document `addText`**.

That matters because the API-level invariance tests **all passed with `processDocument` reverted to per-chunk slicing** — they exercise the helper, not the caller. Classic correct-helper-never-called. With the wiring test in place, reverting fails on both the bit array and the absence of boundary-spanning bigrams.

Also pinned: batch sizes 1 / 7 / 64 / 512 / 100000 produce identical filters; the old text-chunking genuinely differed (so the comparison is not vacuous); the caps and fidelity switch are now reachable; and the real `validateCacheStructure` rejects an older cache version.

## Two fixes to tests from earlier PRs

**The 60-document perf bound was still 600ms.** The widening in #21 silently did not apply — the replacement anchor did not match, and my verification grep only listed the patterns that *had* applied, so I reported three thresholds widened when two were. This is the test that flaked just before the 4.2.0 release. Now 2000ms, still far below the >3s regression cost.

**Two cache fixtures hardcoded `version: 1`.** They now read `CACHE.VERSION`, so a future bump doesn't break tests that are about caching working rather than about a particular number.

## Verification

- `npm run build` — passes
- `npm run test:run` — **150 passing**, stable across 3 consecutive runs
- `npm audit` — 0 vulnerabilities
- Indexing benchmarked old vs new; no regression, a 2.2x improvement on long notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
